### PR TITLE
Fix Login to Select Community Flow

### DIFF
--- a/app/src/main/java/app/igormatos/botaprarodar/presentation/login/BaseAuthActivity.kt
+++ b/app/src/main/java/app/igormatos/botaprarodar/presentation/login/BaseAuthActivity.kt
@@ -69,11 +69,38 @@ abstract class BaseAuthActivity : AppCompatActivity() {
         )
     }
 
+    protected fun showAlertConfirmDialog(
+        @StringRes title: Int,
+        @StringRes message: Int,
+        onConfirm: (() -> Unit)? = null,
+        onCancel: (() -> Unit)? = null
+
+    ) {
+        showConfirmDialog(
+            R.drawable.ic_warning,
+            title,
+            message,
+            onConfirm,
+            onCancel
+        )
+    }
+
     private fun showConfirmDialog(
         @DrawableRes icon: Int,
         @StringRes title: Int,
         @StringRes message: Int,
         click: (() -> Unit)? = null
+
+    ) {
+        showConfirmDialog(icon, title, message, click, null)
+    }
+
+    private fun showConfirmDialog(
+        @DrawableRes icon: Int,
+        @StringRes title: Int,
+        @StringRes message: Int,
+        onConfirm: (() -> Unit)? = null,
+        onCancel: (() -> Unit)? = null
 
     ) {
         val dialogModel = CustomDialogModel(
@@ -82,7 +109,11 @@ abstract class BaseAuthActivity : AppCompatActivity() {
             message = getString(message),
             primaryButtonText = getString(R.string.ok),
             primaryButtonListener = {
-                click?.invoke()
+                onConfirm?.invoke()
+            },
+            secondaryButtonText = if (onCancel != null) getString(R.string.cancel) else null,
+            secondaryButtonListener = {
+                onCancel?.invoke()
             }
         )
 

--- a/app/src/main/java/app/igormatos/botaprarodar/presentation/login/LoginActivity.kt
+++ b/app/src/main/java/app/igormatos/botaprarodar/presentation/login/LoginActivity.kt
@@ -118,6 +118,10 @@ class LoginActivity : BaseAuthActivity() {
         val intent = SelectCommunityActivity.getStartIntent(this)
         intent.putExtra("adminId", admin.id)
         intent.putExtra("adminEmail", admin.email)
+
+        intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or
+                Intent.FLAG_ACTIVITY_CLEAR_TOP
+
         startActivity(intent)
         finish()
     }

--- a/app/src/main/java/app/igormatos/botaprarodar/presentation/login/selectCommunity/SelectCommunityActivity.kt
+++ b/app/src/main/java/app/igormatos/botaprarodar/presentation/login/selectCommunity/SelectCommunityActivity.kt
@@ -51,6 +51,19 @@ class SelectCommunityActivity : BaseAuthActivity() {
         viewModel.loadCommunities()
     }
 
+    override fun onBackPressed() {
+
+        showAlertConfirmDialog(
+            title = R.string.warning,
+            message = R.string.login_return_confirmation,
+            onConfirm = {
+                viewModel.forceUserLogout()
+                navigateToLoginActivity()
+            },
+            onCancel = {}
+        )
+    }
+
     private fun setupAdapter() {
         chooseCommunityAdapter = CommunityAdapter(arrayListOf()) { community ->
             clickCommunity(community)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -23,6 +23,7 @@
     <string name="login_error">Falha no login</string>
     <string name="admin_registration_error">Falha ao criar usuário administrador</string>
     <string name="add_community">Adicionar comunidade</string>
+    <string name="login_return_confirmation">Essa ação irá deslogar você. Clique OK para confirmar?</string>
     <string name="login_no_communities_allowed">Solicite o vínculo com alguma comunidade a Ameciclo</string>
     <string name="login_load_communities_error">Erro ao obter comunidades</string>
     <string name="login_retry_load_community">Tentar novamente</string>
@@ -309,6 +310,7 @@
     <string name="title_resend_email">Reenvio de email</string>
     <string name="message_resend_email">Reenviado email com sucesso</string>
     <string name="ok">OK</string>
+    <string name="cancel">Cancelar</string>
 
     <!-- Password Revocery Activity -->
     <string name="enter_email_to_recover_password">Insira o e-mail associado à sua conta e iremos enviar um link para recuperar a sua senha.</string>


### PR DESCRIPTION
Agora quando tenta voltar da tela selecionar comunidades após login, é apresentado um dialog de confirmação.
Foi corrigido o erro que permitia ir para tela da Home ao clicar voltar